### PR TITLE
Add Infomaniak as OAuth 2.0 provider with org membership check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
 GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your-client-secret
 FLASK_SECRET_KEY=generate-a-random-string
+
+INFOMANIAK_CLIENT_ID=your-infomaniak-client-id
+INFOMANIAK_CLIENT_SECRET=your-infomaniak-client-secret
+INFOMANIAK_ORG_ID=your-infomaniak-org-id

--- a/app.py
+++ b/app.py
@@ -21,6 +21,16 @@ oauth.register(
     client_kwargs={"scope": "openid email profile"},
 )
 
+oauth.register(
+    name="infomaniak",
+    client_id=os.environ.get("INFOMANIAK_CLIENT_ID"),
+    client_secret=os.environ.get("INFOMANIAK_CLIENT_SECRET"),
+    server_metadata_url="https://login.infomaniak.com/.well-known/openid-configuration",
+    client_kwargs={"scope": "openid email profile accounts"},
+)
+
+INFOMANIAK_ORG_ID = os.environ.get("INFOMANIAK_ORG_ID")
+
 
 @app.route("/")
 def index():
@@ -39,6 +49,33 @@ def callback():
     token = oauth.google.authorize_access_token()
     userinfo = token.get("userinfo")
     session["user"] = dict(userinfo)
+    session["user"]["provider"] = "google"
+    return redirect(url_for("profile"))
+
+
+@app.route("/login/infomaniak")
+def login_infomaniak():
+    redirect_uri = url_for("callback_infomaniak", _external=True)
+    return oauth.infomaniak.authorize_redirect(redirect_uri)
+
+
+@app.route("/callback/infomaniak")
+def callback_infomaniak():
+    token = oauth.infomaniak.authorize_access_token()
+    userinfo = token.get("userinfo")
+
+    # Verify the user belongs to the required Infomaniak organization
+    if INFOMANIAK_ORG_ID:
+        resp = oauth.infomaniak.get(
+            "https://api.infomaniak.com/1/account", token=token
+        )
+        accounts = resp.json().get("data", [])
+        org_id = int(INFOMANIAK_ORG_ID)
+        if not any(a.get("id") == org_id for a in accounts):
+            return render_template("denied.html"), 403
+
+    session["user"] = dict(userinfo)
+    session["user"]["provider"] = "infomaniak"
     return redirect(url_for("profile"))
 
 

--- a/static/style.css
+++ b/static/style.css
@@ -62,6 +62,14 @@ p {
     background: #555;
 }
 
+.btn-infomaniak {
+    background: #0098ff;
+}
+
+.btn-infomaniak:hover {
+    background: #007acc;
+}
+
 .avatar {
     width: 80px;
     height: 80px;

--- a/templates/denied.html
+++ b/templates/denied.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Access Denied</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <main>
+        <h1>Access Denied</h1>
+        <p>Your account is not a member of the required Infomaniak organization.</p>
+        <a href="{{ url_for('index') }}" class="btn btn-secondary">Back to login</a>
+    </main>
+</body>
+</html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -13,6 +13,7 @@
         {% endif %}
         <h1>Sign In</h1>
         <a href="{{ url_for('login') }}" class="btn">Sign in with Google</a>
+        <a href="{{ url_for('login_infomaniak') }}" class="btn btn-infomaniak">Sign in with Infomaniak</a>
     </main>
 </body>
 </html>

--- a/templates/profile.html
+++ b/templates/profile.html
@@ -9,6 +9,9 @@
 <body>
     <main>
         <h1>Your Profile</h1>
+        {% if user.provider %}
+        <p>Signed in via <strong>{{ user.provider }}</strong></p>
+        {% endif %}
 
         {% if user.picture %}
         <img src="{{ user.picture }}" alt="Profile picture" class="avatar">


### PR DESCRIPTION
Adds Infomaniak as a second OAuth provider. Only members of a configured Infomaniak organization are allowed to sign in.

**Changes:**
- `app.py` — Register Infomaniak OAuth provider, add `/login/infomaniak` and `/callback/infomaniak` routes, verify org membership via Infomaniak API
- `.env.example` — Add `INFOMANIAK_CLIENT_ID`, `INFOMANIAK_CLIENT_SECRET`, `INFOMANIAK_ORG_ID`
- `templates/login.html` — Add "Sign in with Infomaniak" button
- `templates/denied.html` — New 403 page for users not in the required org
- `templates/profile.html` — Show which provider was used to sign in
- `static/style.css` — Add Infomaniak button style

**Setup:** Create an OAuth app at manager.infomaniak.com (Profile → Applications), set redirect URI to `<domain>/callback/infomaniak`, and populate the three `INFOMANIAK_*` env vars.

Closes #5